### PR TITLE
Use terminal for validation

### DIFF
--- a/autoload/xml/geekodoc5.vim
+++ b/autoload/xml/geekodoc5.vim
@@ -1,7 +1,7 @@
 " Vim XML data file
 " Last Change: 2022-06-22
 
-let g:xmldata_/home/tbazant/.vim/plugged/vim-daps/autoload/xml/geekodoc5 = {
+let g:xmldata_geekodoc5 = {
 \ 'vimxmlentities': ['lt', 'gt', 'amp', 'apos', 'quot'],
 \ 'vimxmlroot': ['abstract', 'annotation', 'appendix', 'article', 'book', 'calloutlist', 'chapter', 'enumsynopsis', 'example', 'figure', 'formalgroup', 'formalpara', 'glossary', 'glossdiv', 'glosslist', 'imagedata', 'imageobject', 'important', 'index', 'indexdiv', 'informalexample', 'informalfigure', 'informaltable', 'inlinemediaobject', 'itemizedlist', 'legalnotice', 'macrosynopsis', 'msgexplan', 'namespacesynopsis', 'note', 'orderedlist', 'para', 'part', 'partintro', 'personblurb', 'preface', 'procedure', 'programlisting', 'qandadiv', 'qandaentry', 'qandaset', 'refentry', 'reference', 'refsect1', 'refsect2', 'refsect3', 'refsection', 'refsynopsisdiv', 'revhistory', 'screen', 'sect1', 'sect2', 'sect3', 'sect4', 'sect5', 'section', 'set', 'simplelist', 'step', 'stepalternatives', 'table', 'task', 'taskprerequisites', 'taskrelated', 'tasksummary', 'textobject', 'tip', 'topic', 'typedefsynopsis', 'unionsynopsis', 'variablelist', 'videodata', 'videoobject', 'warning', 'xi:include'],
 \ 'edition': [

--- a/doc/daps.txt
+++ b/doc/daps.txt
@@ -127,10 +127,6 @@ g:daps_dapsroot = <directory>
   Use daps from a git checkout directory instead of the default RPM installation.
   This option is useful if you want to try the development version of daps.
 
-g:daps_optipng_before_build = 0 or 1
-  Check for non-optimized images corresponding to the current DC-* file and optimize
-  them if necessary when running :DapsBuild(). Default is 0.
-
 g:daps_debug = 0 or 1
   Set this to output debug messages, either to an editor windowm, or a file specified with
   'g:daps_log_file'

--- a/plugin/daps.vim
+++ b/plugin/daps.vim
@@ -58,7 +58,10 @@ endif
 
 " daps xmlformat
 if !exists(":DapsXmlFormat")
-  command -nargs=0 -range=% DapsXmlFormat <line1>,<line2>call s:DapsXmlFormat(<f-args>)
+  command -nargs=0 -range=% DapsXmlFormat 
+    \ let b:pos = winsaveview() |
+    \ <line1>,<line2>call s:DapsXmlFormat(<f-args>) |
+    \ call winrestview(b:pos)
 endif
 
 " daps html

--- a/plugin/daps.vim
+++ b/plugin/daps.vim
@@ -108,8 +108,6 @@ endif
 
 " read g:daps_* variables from ~/.vimrc and set buffer-wide defaults
 function s:Init()
-  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
-
   " fill the  DB schema resolving hash
   let g:daps_db_schema = {
         \'https://github.com/openSUSE/geekodoc/raw/master/geekodoc/rng/geekodoc5-flat.rng': 'geekodoc5',
@@ -690,8 +688,6 @@ endfunction
 " formats the XML source
 function s:DapsXmlFormat() range
   call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
-  " save the current cursor position as a mark
-  let winview = winsaveview()
   " check if the current buffer is valid
   if s:DapsValidateFile() == 0
     call s:dbg('range a:firstline -> ' . a:firstline)
@@ -710,8 +706,6 @@ function s:DapsXmlFormat() range
       silent execute("normal lV%" . indent_size . ">")
     endif
   endif
-  " go back to the saved cursor position
-  call winrestview(winview)
 endfunction
 
 " imports Entities from a file to a DTD file

--- a/plugin/daps.vim
+++ b/plugin/daps.vim
@@ -108,6 +108,7 @@ endif
 
 " read g:daps_* variables from ~/.vimrc and set buffer-wide defaults
 function s:Init()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
 
   " fill the  DB schema resolving hash
   let g:daps_db_schema = {
@@ -250,11 +251,13 @@ endfunction
 
 " lists all DC files in the current directory
 function s:ListDCfiles(A,L,P)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   return system("ls -1 " . g:dcfile_glob_pattern . "*")
 endfunction
 
 " lists XML dictionaries from vim-daps plugin
 function s:ListXMLdictionaries(A,L,P)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   " make sure the dict list is unique
   let dict_list = filter(values(g:daps_db_schema),'index(values(g:daps_db_schema), v:val, v:key+1)==-1')
   call s:dbg('dict_list -> ' . dic_list)
@@ -265,12 +268,14 @@ endfunction
 
 " list all <xref>s' IDs from the current buffer
 function s:ListXrefTargets(A,L,P)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   let cmd = 'xsltproc ' . b:dapsroot . '/tools/get-all-xrefsids.xsl ' . expand('%') . ' | sort -u'
   return system(cmd)
 endfunction
 
 " import all XML IDs given a DC-file
 function s:DapsImportXmlIds()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if !empty(s:IsDCfileSet())
     " grep MAIN file out of the DC-file
     let main_file = matchstr(system('grep "^\s*MAIN=" ' . b:dc_file), '"\zs[^"]\+\ze"')
@@ -283,6 +288,7 @@ endfunction
 
 " ask for DC file
 function s:AskForDCFile()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   call inputsave()
   let dc_file = input("Enter DC file: ", g:dcfile_glob_pattern, "file")
   call inputrestore()
@@ -292,6 +298,7 @@ endfunction
 
 " set current buffer's DC-* file
 function s:DapsSetDCfile(dc_file)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if filereadable(a:dc_file)
     "set dc_file for current buffer
     let b:dc_file = a:dc_file
@@ -308,6 +315,7 @@ endfunction
 
 " implement `daps list-file`
 function s:DapsOpenTarget(...)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if a:0 > 0
     " check if XML ID was provided via cmdline
     call s:dbg("XML ID supplied on the command line -> " . a:1)
@@ -346,6 +354,7 @@ endfunction
 
 " list all XML IDs
 function s:ListXmlIds(A,L,P)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   " get list of XML IDs in the current file
   let xmlids = system('xsltproc ' . b:dapsroot . '/daps-xslt/common/get-all-xmlids.xsl ' . expand('%'))
   call s:dbg('Num of XML IDs -> ' . len(xmlids))
@@ -354,6 +363,7 @@ endfunction
 
 " find pages which refer to provided xml:id via <xref linkend>
 function s:DapsOpenReferers(...)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if a:0 > 0
     " check if XML ID was provided via cmdline
     call s:dbg("XML ID supplied on the command line -> " . a:1)
@@ -402,6 +412,7 @@ endfunction
 
 " set doctype for DB documents
 function s:DapsSetDoctype(...)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if a:0 == 0
     call s:dbg('No doctype specified on the cmdline, trying .vimrc')
     if exists("g:daps_doctype")
@@ -421,6 +432,7 @@ endfunction
 
 " check if DC file was previously set via DapsSetDCfile()
 function s:IsDCfileSet()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if exists("b:dc_file")
     return b:dc_file
   elseif exists("g:daps_dc_file")
@@ -434,6 +446,7 @@ endfunction
 " run command 'cmd' in a terminal buffer named 'name' with exit callback
 " 'exit_cb'
 function s:RunCmdTerm(cmd, name, exit_cb)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   let cmd = a:cmd
   let name = a:name
   let exit_cb = a:exit_cb
@@ -455,6 +468,7 @@ endfunction
 
 " validates the document based on the DC file with tab completion
 function s:DapsValidate()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if !empty(s:IsDCfileSet())
     " check whether to run DapsValidateFile first and return 1 on error
     if g:daps_auto_validate_file == 1 && s:DapsValidateFile() == 1
@@ -473,6 +487,7 @@ endfunction
 
 " callback for creating quickfix list with validation errors
 function ValidateQuickfix_cb(job, exit_status)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   let job = a:job
   call s:dbg('job -> ' . job)
   let term_buf_no = ch_getbufnr(job, 'out')
@@ -497,6 +512,7 @@ endfunction
 
 " daps style check
 function s:DapsStylecheck()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   " check for 'sdsc' command
   if !executable('sdsc')
     echoe "Command 'sdsc' was not found"
@@ -614,6 +630,7 @@ endfunction
 
 " builds the current chapter or --rootid
 function s:DapsBuild(target)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if !empty(s:IsDCfileSet())
     " save the build target across buffers
     let s:DapsBuildTarget = a:target
@@ -646,6 +663,7 @@ endfunc
 
 " callback to run build inside a trminal winow
 function BuildTarget_cb(job, exit_status)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   let job = a:job
   call s:dbg('job -> ' . job)
   let term_buf_no = ch_getbufnr(job, 'out')
@@ -700,6 +718,7 @@ endfunction
 " 1) look if arguments are a list of entity files and try to extract Entities;
 " 2) if no argument is given, run getentityname.py to get the list of files
 function s:DapsImportEntities(...)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   if a:0 == 0
     " return for fugitive:// paths
     if expand('%:p') =~ '^fugitive'
@@ -749,6 +768,7 @@ endfunction
 
 " lookup doctype info from xml/schemas.xml file
 function s:DapsLookupSchemasXML()
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   " test for the xml/schemas.xml file
   if filereadable('xml/schemas.xml')
     let x_query = '/t:locatingRules/t:uri/@uri'
@@ -762,6 +782,7 @@ endfunction
 
 " set --buildroot for the current buffer
 function s:DapsSetBuilddir(builddir)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   " check if builddir exists and if it is a writable directory
   if filewritable(a:builddir) == 2
     let b:builddir = a:builddir
@@ -774,6 +795,7 @@ endfunction
 
 " set --styleroot for customstylesheets (overriding DC-* file setting)
 function s:DapsSetStyleroot(styleroot)
+  call s:dbg('# # # # # ' . expand('<sfile>') . ' # # # # #')
   " check if styleroot is writable
   if isdirectory(a:styleroot)
     let b:styleroot = a:styleroot


### PR DESCRIPTION
This update:
* runs validation and build commands in a vim terminal window as callbacks
* in case errors are found, quickfix window is opened for them
* xmlformat now remembers the cursor position
* removed validation from build
* added validation before xmlformat
* improved debugging messages, each function reports itself